### PR TITLE
Added functionality for renaming a GitHub repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Here is the current functionality:
 * `!gh repo delete PagerDuty/lita-github`
   * Deletes the repo you specify, requires confirmation before doing so
   * **Note:** This method is disabled by default, you need to enable it by setting `config.handlers.github.repo_delete_enabled = true` in your configuration file
+* `!gh repo rename PagerDuty/lita-github better-lita-github`
+  * Renames the repo you specify -- requires confirmation
 * `!gh repo teams PagerDuty/lita-github`
   * list all of the teams currently attached to a repo
 * `!gh repo team add <TEAM_ID|TEAM_SLUG> PagerDuty/lita-github`

--- a/lib/lita-github/r.rb
+++ b/lib/lita-github/r.rb
@@ -26,6 +26,9 @@ module LitaGithub
     #  key1:value key2:"value2" key3:'a better value'
     OPT_REGEX ||= /((?:\s+?[a-zA-Z0-9_]+?):(?:(?:".+?")|(?:'.+?')|(?:[a-zA-Z0-9_]+)))/
 
+    # regex matcher for a repo name (not including the org).
+    REPO_NAME_REGEX = '(?<repo_name>[a-zA-Z0-9_\-]+)'
+
     # regex matcher for: Org/repo
     REPO_REGEX = '(?:(?<org>[a-zA-Z0-9_\-]+)(?:\s+?)?\/)?(?:\s+?)?(?<repo>[a-zA-Z0-9_\-]+)'
   end

--- a/lib/lita/handlers/github.rb
+++ b/lib/lita/handlers/github.rb
@@ -81,6 +81,7 @@ module Lita
 
         # Lita::Handlers::GithubRepo
         config.repo_create_enabled              = true
+        config.repo_rename_enabled              = true
         config.repo_delete_enabled              = false
         config.repo_team_add_enabled            = false
         config.repo_team_rm_enabled             = false

--- a/lib/lita/handlers/github_repo.rb
+++ b/lib/lita/handlers/github_repo.rb
@@ -74,7 +74,8 @@ module Lita
         command: true,
         confirmation: true,
         help: {
-          'gh repo rename PagerDuty/lita-github better-lita-github' => 'Rename the PagerDuty/lita-github repo to PagerDuty/better-lita-github'
+          'gh repo rename PagerDuty/lita-github better-lita-github' =>
+            'Rename the PagerDuty/lita-github repo to PagerDuty/better-lita-github'
         }
       )
 
@@ -332,7 +333,7 @@ module Lita
         full_name = rpo(org, repo)
         reply = nil
         begin
-          octo.edit_repository(full_name, { :name => new_repo } )
+          octo.edit_repository(full_name, name: new_repo)
         ensure
           if repo?(rpo(org, new_repo))
             reply = t('repo_rename.pass', org: org, old_repo: repo, new_repo: new_repo)

--- a/lib/lita/handlers/github_repo.rb
+++ b/lib/lita/handlers/github_repo.rb
@@ -130,11 +130,11 @@ module Lita
       def repo_rename(response)
         return response.reply(t('method_disabled')) if func_disabled?(__method__)
         org, repo = repo_match(response.match_data)
-        new_repo_name = response.match_data['repo_name']
+        new_repo = response.match_data['repo_name']
 
         return response.reply(t('not_found', org: org, repo: repo)) unless repo?(rpo(org, repo))
 
-        response.reply(rename_repo(org, repo, new_repo_name))
+        response.reply(rename_repo(org, repo, new_repo))
       end
 
       def repo_delete(response)
@@ -328,14 +328,14 @@ module Lita
         reply
       end
 
-      def rename_repo(org, repo, new_repo_name)
+      def rename_repo(org, repo, new_repo)
         full_name = rpo(org, repo)
         reply = nil
         begin
-          octo.edit_repository(full_name, { :name => new_repo_name } )
+          octo.edit_repository(full_name, { :name => new_repo } )
         ensure
-          if repo?(rpo(org, new_repo_name))
-            reply = t('repo_rename.pass', org: org, repo: new_repo_name)
+          if repo?(rpo(org, new_repo))
+            reply = t('repo_rename.pass', org: org, old_repo: repo, new_repo: new_repo)
           else
             reply = t('repo_rename.fail', org: org, repo: repo)
           end

--- a/lib/lita/handlers/github_repo.rb
+++ b/lib/lita/handlers/github_repo.rb
@@ -69,6 +69,16 @@ module Lita
       )
 
       route(
+        /#{LitaGithub::R::A_REG}repo\s+?rename\s+?#{LitaGithub::R::REPO_REGEX}\s+?#{LitaGithub::R::REPO_NAME_REGEX}/,
+        :repo_rename,
+        command: true,
+        confirmation: true,
+        help: {
+          'gh repo rename PagerDuty/lita-github better-lita-github' => 'Rename the PagerDuty/lita-github repo to PagerDuty/better-lita-github'
+        }
+      )
+
+      route(
         /#{LitaGithub::R::A_REG}repo\s+?(teams|team\s+?list)\s+?#{LitaGithub::R::REPO_REGEX}/,
         :repo_teams_list,
         command: true,
@@ -115,6 +125,16 @@ module Lita
         opts = extrapolate_create_opts(opts_parse(response.message.body), org)
 
         response.reply(create_repo(org, repo, opts))
+      end
+
+      def repo_rename(response)
+        return response.reply(t('method_disabled')) if func_disabled?(__method__)
+        org, repo = repo_match(response.match_data)
+        new_repo_name = response.match_data['repo_name']
+
+        return response.reply(t('not_found', org: org, repo: repo)) unless repo?(rpo(org, repo))
+
+        response.reply(rename_repo(org, repo, new_repo_name))
       end
 
       def repo_delete(response)
@@ -303,6 +323,21 @@ module Lita
             reply = t('repo_create.pass', org: org, repo: repo, repo_url: repo_url)
           else
             reply = t('repo_create.fail', org: org, repo: repo)
+          end
+        end
+        reply
+      end
+
+      def rename_repo(org, repo, new_repo_name)
+        full_name = rpo(org, repo)
+        reply = nil
+        begin
+          octo.edit_repository(full_name, { :name => new_repo_name } )
+        ensure
+          if repo?(rpo(org, new_repo_name))
+            reply = t('repo_rename.pass', org: org, repo: new_repo_name)
+          else
+            reply = t('repo_rename.fail', org: org, repo: repo)
           end
         end
         reply

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -26,6 +26,9 @@ en:
           pass: "Created %{org}/%{repo}: %{repo_url}"
           fail: "Unable to create %{org}/%{repo}"
           exists: "Unable to create %{org}/%{repo} as it already exists"
+        repo_rename:
+          pass: "Renamed %{org}/%{old_repo} to %{org}/%{new_repo}"
+          fail: "Unable to rename %{org}/%{repo}"
         repo_delete:
           pass: "Deleted %{org}/%{repo}"
           fail: "Unable to delete %{org}/%{repo}"


### PR DESCRIPTION
As a very small HackDay (13 February 2015) project.

Tested using the Lita Vagrant VM and my own Github account using an application authentication token.

@theckman 