### PR TITLE
add 'from' adverb to regex for repo team management

### DIFF
--- a/lib/lita/handlers/github_repo.rb
+++ b/lib/lita/handlers/github_repo.rb
@@ -91,7 +91,7 @@ module Lita
 
       # rubocop:disable Metrics/LineLength
       route(
-        /#{LitaGithub::R::A_REG}repo\s+?team\s+?(?<action>add|rm)\s+?(?<team>[a-zA-Z0-9_\-]+?)(\s+?to)?\s+?#{LitaGithub::R::REPO_REGEX}/,
+        /#{LitaGithub::R::A_REG}repo\s+?team\s+?(?<action>add|rm)\s+?(?<team>[a-zA-Z0-9_\-]+?)(\s+?(?:to|from))?\s+?#{LitaGithub::R::REPO_REGEX}/,
         :repo_team_router,
         command: true,
         confirmation: true,

--- a/spec/unit/lita/handlers/github_repo_spec.rb
+++ b/spec/unit/lita/handlers/github_repo_spec.rb
@@ -53,8 +53,10 @@ describe Lita::Handlers::GithubRepo, lita_handler: true do
   it { is_expected.to route_command('gh repo team add 42 to lita-test').to(:repo_team_router) }
   it { is_expected.to route_command('gh repo team rm everyone GrapeDuty/lita-test').to(:repo_team_router) }
   it { is_expected.to route_command('gh repo team rm everyone to GrapeDuty/lita-test').to(:repo_team_router) }
+  it { is_expected.to route_command('gh repo team rm everyone from GrapeDuty/lita-test').to(:repo_team_router) }
   it { is_expected.to route_command('gh repo team rm everyone lita-test').to(:repo_team_router) }
   it { is_expected.to route_command('gh repo team rm everyone to lita-test').to(:repo_team_router) }
+  it { is_expected.to route_command('gh repo team rm everyone from lita-test').to(:repo_team_router) }
   it { is_expected.to route_command('gh repo team rm 42 GrapeDuty/lita-test').to(:repo_team_router) }
   it { is_expected.to route_command('gh repo team rm 42 to GrapeDuty/lita-test').to(:repo_team_router) }
   it { is_expected.to route_command('gh repo team rm 42 lita-test').to(:repo_team_router) }


### PR DESCRIPTION
When removing a team from a GitHub repo, the word `to` was used and `from` was not permitted. This, in English, doesn't make sense. So I've added the `from` adverb to the regex and added tests to ensure the changes route properly.