### PR TITLE
reduce number of Ruby versions we build against

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,7 @@ services:
   - redis-server
 language: ruby
 rvm:
+  - 2.2.2
+  - 2.2.1
   - 2.1.5
   - 2.1.4
-  - 2.1.3
-  - 2.1.2
-  - 2.1.1
-  - 2.1.0


### PR DESCRIPTION
Only build against two-most recent stable versions of Ruby, and only the two-most recent revisions.