### PR TITLE
make the stubs actually stub in the specs

### DIFF
--- a/spec/unit/lita/handlers/github_issues_spec.rb
+++ b/spec/unit/lita/handlers/github_issues_spec.rb
@@ -97,9 +97,9 @@ describe Lita::Handlers::GithubIssues, lita_handler: true do
         }
       ]
       @octo_obj = double('Octokit::Client', list_issues: issues)
-      allow(github_issues).to receive(:octo).and_return(@octo_obj)
-      allow(github_issues).to receive(:repo?).and_return(true)
-      allow(github_issues).to receive(:validate_list_opts).and_return('')
+      allow_any_instance_of(Lita::Handlers::GithubIssues).to receive(:octo).and_return(@octo_obj)
+      allow_any_instance_of(Lita::Handlers::GithubIssues).to receive(:repo?).and_return(true)
+      allow_any_instance_of(Lita::Handlers::GithubIssues).to receive(:validate_list_opts).and_return('')
     end
 
     context 'when all goes well' do
@@ -123,7 +123,9 @@ GrapeDuty/lita-test #84: 'YZYZYZYZ' opened by theckman :: https://github.com/Gra
     end
 
     context 'when there is an option that fails validation' do
-      before { allow(github_issues).to receive(:validate_list_opts).and_return('sadpanda') }
+      before do
+        allow_any_instance_of(Lita::Handlers::GithubIssues).to receive(:validate_list_opts).and_return('sadpanda')
+      end
 
       it 'should reply with the response from .validate_list_opts' do
         send_command('gh issues GrapeDuty/lita-test')
@@ -132,7 +134,9 @@ GrapeDuty/lita-test #84: 'YZYZYZYZ' opened by theckman :: https://github.com/Gra
     end
 
     context 'when the repo is not found' do
-      before { allow(github_issues).to receive(:repo?).and_return(false) }
+      before do
+        allow_any_instance_of(Lita::Handlers::GithubIssues).to receive(:repo?).and_return(false)
+      end
 
       it 'should reply with response indicating repo not found' do
         send_command('gh issues GrapeDuty/lita-test')
@@ -141,7 +145,9 @@ GrapeDuty/lita-test #84: 'YZYZYZYZ' opened by theckman :: https://github.com/Gra
     end
 
     context 'when an option passes validation, but fails from GitHub' do
-      before { allow(@octo_obj).to receive(:list_issues).and_raise(Octokit::UnprocessableEntity.new) }
+      before do
+        allow(@octo_obj).to receive(:list_issues).and_raise(Octokit::UnprocessableEntity.new)
+      end
 
       it 'should reply indicating an issue was hit and include the exception message' do
         send_command('gh issues GrapeDuty/lita-test')
@@ -151,7 +157,9 @@ Octokit::UnprocessableEntity"
     end
 
     context 'when there is a general error when calling GitHub' do
-      before { allow(@octo_obj).to receive(:list_issues).and_raise(StandardError.new) }
+      before do
+        allow(@octo_obj).to receive(:list_issues).and_raise(StandardError.new)
+      end
 
       it 'should reply indicating an issue was hit and include the exception message' do
         send_command('gh issues GrapeDuty/lita-test')

--- a/spec/unit/lita/handlers/github_org_spec.rb
+++ b/spec/unit/lita/handlers/github_org_spec.rb
@@ -135,8 +135,8 @@ describe Lita::Handlers::GithubOrg, lita_handler: true do
       ]
       conf_obj = double('Lita::Configuration', default_org: 'GrapeDuty')
       @octo_obj = double('Octokit::Client', organization_teams: @teams)
-      allow(github_org).to receive(:config).and_return(conf_obj)
-      allow(github_org).to receive(:octo).and_return(@octo_obj)
+      allow_any_instance_of(Lita::Handlers::GithubOrg).to receive(:config).and_return(conf_obj)
+      allow_any_instance_of(Lita::Handlers::GithubOrg).to receive(:octo).and_return(@octo_obj)
     end
 
     context 'when provided a valid org' do
@@ -169,9 +169,9 @@ Name: HeckmanTest, Slug: heckmantest, ID: 42, Perms: push
       @octo_obj = double('Octokit::Client', create_team: @team)
       @perms = %w(pull push)
       @conf_obj = double('Lita::Config', org_team_add_allowed_perms: @perms)
-      allow(github_org).to receive(:config).and_return(@conf_obj)
-      allow(github_org).to receive(:func_disabled?).and_return(false)
-      allow(github_org).to receive(:octo).and_return(@octo_obj)
+      allow_any_instance_of(Lita::Handlers::GithubOrg).to receive(:config).and_return(@conf_obj)
+      allow_any_instance_of(Lita::Handlers::GithubOrg).to receive(:func_disabled?).and_return(false)
+      allow_any_instance_of(Lita::Handlers::GithubOrg).to receive(:octo).and_return(@octo_obj)
     end
 
     context 'when all goes well' do
@@ -184,7 +184,9 @@ Name: HeckmanTest, Slug: heckmantest, ID: 42, Perms: push
     end
 
     context 'when the method is disabled' do
-      before { allow(github_org).to receive(:func_disabled?).and_return(true) }
+      before do
+        allow_any_instance_of(Lita::Handlers::GithubOrg).to receive(:func_disabled?).and_return(true)
+      end
 
       it 'should return the method disabled error' do
         send_command('gh org team add GrapeDuty name:"HeckmanTest" perms:pull')
@@ -231,10 +233,10 @@ Missing the perms option
     before do
       @team = { name: 'HeckmanTest', id: 42, slug: 'heckmantest', permission: 'pull' }
       @octo_obj = double('Octokit::Client', delete_team: true)
-      allow(github_org).to receive(:config).and_return(@conf_obj)
-      allow(github_org).to receive(:func_disabled?).and_return(false)
-      allow(github_org).to receive(:octo).and_return(@octo_obj)
-      allow(github_org).to receive(:team?).with('42').and_return(@team)
+      allow_any_instance_of(Lita::Handlers::GithubOrg).to receive(:config).and_return(@conf_obj)
+      allow_any_instance_of(Lita::Handlers::GithubOrg).to receive(:func_disabled?).and_return(false)
+      allow_any_instance_of(Lita::Handlers::GithubOrg).to receive(:octo).and_return(@octo_obj)
+      allow_any_instance_of(Lita::Handlers::GithubOrg).to receive(:team?).with('42').and_return(@team)
     end
 
     context 'when all goes well' do
@@ -245,7 +247,9 @@ Missing the perms option
     end
 
     context 'when the method is disabled' do
-      before { allow(github_org).to receive(:func_disabled?).and_return(true) }
+      before do
+        allow_any_instance_of(Lita::Handlers::GithubOrg).to receive(:func_disabled?).and_return(true)
+      end
 
       it 'should return the method disabled error' do
         send_command('gh org team rm GrapeDuty 42')
@@ -254,7 +258,9 @@ Missing the perms option
     end
 
     context 'when the team does not exist' do
-      before { allow(github_org).to receive(:team?).with('42').and_return(false) }
+      before do
+        allow_any_instance_of(Lita::Handlers::GithubOrg).to receive(:team?).with('42').and_return(false)
+      end
 
       it 'should respond with the team not found error' do
         send_command('gh org team rm GrapeDuty 42')
@@ -289,9 +295,9 @@ Missing the perms option
       @conf_obj = double('Lita::Config', default_org: 'GrapeDuty')
       allow(@octo_obj).to receive(:user).with(no_args).and_return(@self_user)
       allow(@octo_obj).to receive(:user).with('theckman').and_return(@t_user)
-      allow(github_org).to receive(:func_disabled?).and_return(false)
-      allow(github_org).to receive(:octo).and_return(@octo_obj)
-      allow(github_org).to receive(:cofig).and_return(@conf_obj)
+      allow_any_instance_of(Lita::Handlers::GithubOrg).to receive(:func_disabled?).and_return(false)
+      allow_any_instance_of(Lita::Handlers::GithubOrg).to receive(:octo).and_return(@octo_obj)
+      allow_any_instance_of(Lita::Handlers::GithubOrg).to receive(:cofig).and_return(@conf_obj)
     end
 
     context 'when all goes well' do
@@ -302,7 +308,9 @@ Missing the perms option
     end
 
     context 'when the method is disabled' do
-      before { allow(github_org).to receive(:func_disabled?).and_return(true) }
+      before do
+        allow_any_instance_of(Lita::Handlers::GithubOrg).to receive(:func_disabled?).and_return(true)
+      end
 
       it 'should return the method disabled error' do
         send_command('gh org eject GrapeDuty theckman')
@@ -368,10 +376,10 @@ Missing the perms option
       @conf_obj = double('Lita::Config', default_org: 'GrapeDuty')
       allow(@octo_obj).to receive(:user).with(no_args).and_return(@self_user)
       allow(@octo_obj).to receive(:user).with('theckman').and_return(@t_user)
-      allow(github_org).to receive(:func_disabled?).and_return(false)
-      allow(github_org).to receive(:octo).and_return(@octo_obj)
-      allow(github_org).to receive(:cofig).and_return(@conf_obj)
-      allow(github_org).to receive(:team_id).and_return(42)
+      allow_any_instance_of(Lita::Handlers::GithubOrg).to receive(:func_disabled?).and_return(false)
+      allow_any_instance_of(Lita::Handlers::GithubOrg).to receive(:octo).and_return(@octo_obj)
+      allow_any_instance_of(Lita::Handlers::GithubOrg).to receive(:cofig).and_return(@conf_obj)
+      allow_any_instance_of(Lita::Handlers::GithubOrg).to receive(:team_id).and_return(42)
     end
 
     context 'when all goes well' do
@@ -382,7 +390,9 @@ Missing the perms option
     end
 
     context 'when the method is disabled' do
-      before { allow(github_org).to receive(:func_disabled?).and_return(true) }
+      before do
+        allow_any_instance_of(Lita::Handlers::GithubOrg).to receive(:func_disabled?).and_return(true)
+      end
 
       it 'should return the method disabled error' do
         send_command('gh org user add GrapeDuty heckmantest theckman')
@@ -448,10 +458,10 @@ Missing the perms option
       @conf_obj = double('Lita::Config', default_org: 'GrapeDuty')
       allow(@octo_obj).to receive(:user).with(no_args).and_return(@self_user)
       allow(@octo_obj).to receive(:user).with('theckman').and_return(@t_user)
-      allow(github_org).to receive(:func_disabled?).and_return(false)
-      allow(github_org).to receive(:octo).and_return(@octo_obj)
-      allow(github_org).to receive(:cofig).and_return(@conf_obj)
-      allow(github_org).to receive(:team_id).and_return(42)
+      allow_any_instance_of(Lita::Handlers::GithubOrg).to receive(:func_disabled?).and_return(false)
+      allow_any_instance_of(Lita::Handlers::GithubOrg).to receive(:octo).and_return(@octo_obj)
+      allow_any_instance_of(Lita::Handlers::GithubOrg).to receive(:cofig).and_return(@conf_obj)
+      allow_any_instance_of(Lita::Handlers::GithubOrg).to receive(:team_id).and_return(42)
     end
 
     context 'when all goes well' do
@@ -462,7 +472,9 @@ Missing the perms option
     end
 
     context 'when the method is disabled' do
-      before { allow(github_org).to receive(:func_disabled?).and_return(true) }
+      before do
+        allow_any_instance_of(Lita::Handlers::GithubOrg).to receive(:func_disabled?).and_return(true)
+      end
 
       it 'should return the method disabled error' do
         send_command('gh org user rm GrapeDuty heckmantest theckman')

--- a/spec/unit/lita/handlers/github_pr_spec.rb
+++ b/spec/unit/lita/handlers/github_pr_spec.rb
@@ -52,7 +52,7 @@ describe Lita::Handlers::GithubPR, lita_handler: true do
   describe '.merge_pr' do
     before do
       @octo_obj = double('Octokit::Client', merge_pull_request: :ohai)
-      allow(github_pr).to receive(:octo).and_return(@octo_obj)
+      allow_any_instance_of(Lita::Handlers::GithubPR).to receive(:octo).and_return(@octo_obj)
     end
 
     let(:pr_num) { 42 }
@@ -167,7 +167,7 @@ describe Lita::Handlers::GithubPR, lita_handler: true do
       @user_obj = { name: 'Tim Heckman' }
       @cs_obj = { state: 'success' }
       @octo_obj = double('Octokit::Client', user: @user_obj, combined_status: @cs_obj)
-      allow(github_pr).to receive(:octo).and_return(@octo_obj)
+      allow_any_instance_of(Lita::Handlers::GithubPR).to receive(:octo).and_return(@octo_obj)
     end
 
     let(:pr_obj) do
@@ -217,7 +217,7 @@ describe Lita::Handlers::GithubPR, lita_handler: true do
     context 'when user has no name set' do
       before do
         @octo_obj = double('Octokit::Client', user: {}, combined_status: @cs_obj)
-        allow(github_pr).to receive(:octo).and_return(@octo_obj)
+        allow_any_instance_of(Lita::Handlers::GithubPR).to receive(:octo).and_return(@octo_obj)
       end
 
       it 'should not include the real name parenthesis' do
@@ -269,7 +269,7 @@ describe Lita::Handlers::GithubPR, lita_handler: true do
     before do
       @user_obj = { name: 'Tim Heckman' }
       @octo_obj = double('Octokit::Client', user: @user_obj)
-      allow(github_pr).to receive(:octo).and_return(@octo_obj)
+      allow_any_instance_of(Lita::Handlers::GithubPR).to receive(:octo).and_return(@octo_obj)
     end
 
     let(:pr_obj) do
@@ -320,7 +320,7 @@ describe Lita::Handlers::GithubPR, lita_handler: true do
         before do
           @user_obj = {}
           @octo_obj = double('Octokit::Client', user: @user_obj)
-          allow(github_pr).to receive(:octo).and_return(@octo_obj)
+          allow_any_instance_of(Lita::Handlers::GithubPR).to receive(:octo).and_return(@octo_obj)
         end
 
         it 'should set the :merged_by key without parenthesis' do
@@ -352,11 +352,11 @@ describe Lita::Handlers::GithubPR, lita_handler: true do
 
   describe '.build_pr_info' do
     before do
-      allow(github_pr).to receive(:build_pr_header!).and_return(nil)
-      allow(github_pr).to receive(:build_pr_commitinfo!).and_return(nil)
-      allow(github_pr).to receive(:build_pr_status!).and_return(nil)
-      allow(github_pr).to receive(:build_pr_merge!).and_return(nil)
-      allow(github_pr).to receive(:build_pr_comments!).and_return(nil)
+      allow_any_instance_of(Lita::Handlers::GithubPR).to receive(:build_pr_header!).and_return(nil)
+      allow_any_instance_of(Lita::Handlers::GithubPR).to receive(:build_pr_commitinfo!).and_return(nil)
+      allow_any_instance_of(Lita::Handlers::GithubPR).to receive(:build_pr_status!).and_return(nil)
+      allow_any_instance_of(Lita::Handlers::GithubPR).to receive(:build_pr_merge!).and_return(nil)
+      allow_any_instance_of(Lita::Handlers::GithubPR).to receive(:build_pr_comments!).and_return(nil)
     end
 
     let(:pr_obj) { :ohai }
@@ -366,27 +366,27 @@ describe Lita::Handlers::GithubPR, lita_handler: true do
     end
 
     it 'should call .build_pr_header!' do
-      expect(github_pr).to receive(:build_pr_header!).with({}, pr_obj).and_return(nil)
+      expect_any_instance_of(Lita::Handlers::GithubPR).to receive(:build_pr_header!).with({}, pr_obj).and_return(nil)
       github_pr.send(:build_pr_info, pr_obj, full_name)
     end
 
     it 'should call .build_pr_commitinfo!' do
-      expect(github_pr).to receive(:build_pr_commitinfo!).with({}, pr_obj).and_return(nil)
+      expect_any_instance_of(Lita::Handlers::GithubPR).to receive(:build_pr_commitinfo!).with({}, pr_obj).and_return(nil)
       github_pr.send(:build_pr_info, pr_obj, full_name)
     end
 
     it 'should call .build_pr_status!' do
-      expect(github_pr).to receive(:build_pr_status!).with({}, pr_obj, full_name).and_return(nil)
+      expect_any_instance_of(Lita::Handlers::GithubPR).to receive(:build_pr_status!).with({}, pr_obj, full_name).and_return(nil)
       github_pr.send(:build_pr_info, pr_obj, full_name)
     end
 
     it 'should call .build_pr_merge!' do
-      expect(github_pr).to receive(:build_pr_merge!).with({}, pr_obj).and_return(nil)
+      expect_any_instance_of(Lita::Handlers::GithubPR).to receive(:build_pr_merge!).with({}, pr_obj).and_return(nil)
       github_pr.send(:build_pr_info, pr_obj, full_name)
     end
 
     it 'should call .build_pr_comments!' do
-      expect(github_pr).to receive(:build_pr_comments!).with({}, pr_obj).and_return(nil)
+      expect_any_instance_of(Lita::Handlers::GithubPR).to receive(:build_pr_comments!).with({}, pr_obj).and_return(nil)
       github_pr.send(:build_pr_info, pr_obj, full_name)
     end
   end
@@ -408,7 +408,7 @@ describe Lita::Handlers::GithubPR, lita_handler: true do
     before do
       @merge_status = { sha: 'abc456', merged: true, message: 'Pull Request successfully merged' }
       @octo_obj = double('Octokit::Client', merge_pull_request: @merge_status)
-      allow(github_pr).to receive(:octo).and_return(@octo_obj)
+      allow_any_instance_of(Lita::Handlers::GithubPR).to receive(:octo).and_return(@octo_obj)
     end
 
     context 'when all goes well' do
@@ -423,7 +423,7 @@ describe Lita::Handlers::GithubPR, lita_handler: true do
         @merge_status = { sha: 'abc456', merged: false, message: '*BOOM*' }
         @octo_obj = double('Octokit::Client')
         allow(@octo_obj).to receive(:merge_pull_request).and_raise(StandardError.new)
-        allow(github_pr).to receive(:octo).and_return(@octo_obj)
+        allow_any_instance_of(Lita::Handlers::GithubPR).to receive(:octo).and_return(@octo_obj)
       end
 
       it 'should return nil' do
@@ -445,8 +445,8 @@ describe Lita::Handlers::GithubPR, lita_handler: true do
           review_comments: 2, comments: 1
         }
         @pr_resp = { fail: false, not_found: false, pr: @pr_info }
-        allow(github_pr).to receive(:pull_request).and_return(@pr_resp)
-        allow(github_pr).to receive(:build_pr_info).and_return(@pr_info)
+        allow_any_instance_of(Lita::Handlers::GithubPR).to receive(:pull_request).and_return(@pr_resp)
+        allow_any_instance_of(Lita::Handlers::GithubPR).to receive(:build_pr_info).and_return(@pr_info)
       end
 
       it 'should reply with the expeced output' do
@@ -472,8 +472,8 @@ describe Lita::Handlers::GithubPR, lita_handler: true do
           merged_by: 'theckman (Tim Heckman)', review_comments: 2, comments: 1
         }
         @pr_resp = { fail: false, not_found: false, pr: @pr_info }
-        allow(github_pr).to receive(:pull_request).and_return(@pr_resp)
-        allow(github_pr).to receive(:build_pr_info).and_return(@pr_info)
+        allow_any_instance_of(Lita::Handlers::GithubPR).to receive(:pull_request).and_return(@pr_resp)
+        allow_any_instance_of(Lita::Handlers::GithubPR).to receive(:build_pr_info).and_return(@pr_info)
       end
 
       it 'should reply with the expeced output' do
@@ -492,7 +492,7 @@ describe Lita::Handlers::GithubPR, lita_handler: true do
     context 'when the PR was not found' do
       before do
         @pr_resp = { fail: true, not_found: true, pr: @pr_info }
-        allow(github_pr).to receive(:pull_request).and_return(@pr_resp)
+        allow_any_instance_of(Lita::Handlers::GithubPR).to receive(:pull_request).and_return(@pr_resp)
       end
 
       it 'should reply with the not found error' do
@@ -508,15 +508,15 @@ describe Lita::Handlers::GithubPR, lita_handler: true do
       @pr_obj =  { head: { ref: 'fix-some-bugs' }, title: 'fix bug' }
       @merge_status = { sha: 'abc456', merged: true, message: 'Pull Request successfully merged' }
       @octo_obj = double('Octokit::Client', pull_request: @pr_obj)
-      allow(github_pr).to receive(:octo).and_return(@octo_obj)
-      allow(github_pr).to receive(:func_disabled?).and_return(false)
-      allow(github_pr).to receive(:config).and_return(@cfg_obj)
-      allow(github_pr).to receive(:merge_pr).and_return(@merge_status)
+      allow_any_instance_of(Lita::Handlers::GithubPR).to receive(:octo).and_return(@octo_obj)
+      allow_any_instance_of(Lita::Handlers::GithubPR).to receive(:func_disabled?).and_return(false)
+      allow_any_instance_of(Lita::Handlers::GithubPR).to receive(:config).and_return(@cfg_obj)
+      allow_any_instance_of(Lita::Handlers::GithubPR).to receive(:merge_pr).and_return(@merge_status)
     end
 
     context 'when command disabled' do
       before do
-        allow(github_pr).to receive(:func_disabled?).and_return(true)
+        allow_any_instance_of(Lita::Handlers::GithubPR).to receive(:func_disabled?).and_return(true)
       end
 
       it 'should no-op and say such' do
@@ -538,7 +538,7 @@ describe Lita::Handlers::GithubPR, lita_handler: true do
 
     context 'when merging should succeed' do
       it 'should set the right commit message' do
-        expect(github_pr).to receive(:merge_pr).with(
+        expect_any_instance_of(Lita::Handlers::GithubPR).to receive(:merge_pr).with(
           'GrapeDuty', 'lita-test', '42', "Merge pull request #42 from GrapeDuty/fix-some-bugs\n\nfix bug"
         )
         send_command('shipit GrapeDuty/lita-test #42')
@@ -554,7 +554,7 @@ describe Lita::Handlers::GithubPR, lita_handler: true do
     context 'when merging bombs' do
       before do
         @merge_status = { sha: 'abc456', merged: false, message: '*BOOM*' }
-        allow(github_pr).to receive(:merge_pr).and_return(@merge_status)
+        allow_any_instance_of(Lita::Handlers::GithubPR).to receive(:merge_pr).and_return(@merge_status)
       end
 
       it 'should confirm the failure' do
@@ -571,7 +571,7 @@ describe Lita::Handlers::GithubPR, lita_handler: true do
       before do
         @merge_status = { sha: 'abc456', merged: false, message: '*BOOM*' }
         @octo_obj = double('Octokit::Client', pull_request: @pr_obj)
-        allow(github_pr).to receive(:merge_pr).and_return(nil)
+        allow_any_instance_of(Lita::Handlers::GithubPR).to receive(:merge_pr).and_return(nil)
       end
 
       it 'should confirm the failure' do
@@ -589,8 +589,8 @@ describe Lita::Handlers::GithubPR, lita_handler: true do
     before do
       cfg_obj = double('Lita::Configuration')
       octo_obj = double('Octokit::Client', pull_requests: [])
-      allow(github_pr).to receive(:octo).and_return(octo_obj)
-      allow(github_pr).to receive(:config).and_return(cfg_obj)
+      allow_any_instance_of(Lita::Handlers::GithubPR).to receive(:octo).and_return(octo_obj)
+      allow_any_instance_of(Lita::Handlers::GithubPR).to receive(:config).and_return(cfg_obj)
     end
 
     context 'when there are no pull requests' do
@@ -607,7 +607,7 @@ describe Lita::Handlers::GithubPR, lita_handler: true do
           { title: 'Test1', number: 42, html_url: 'htmlurl', user: { login: 'theckman' } }
         ]
         octo_obj = double('Octokit::Client', pull_requests: pr)
-        allow(github_pr).to receive(:octo).and_return(octo_obj)
+        allow_any_instance_of(Lita::Handlers::GithubPR).to receive(:octo).and_return(octo_obj)
       end
 
       it 'should reply with the PRs' do
@@ -643,7 +643,7 @@ describe Lita::Handlers::GithubPR, lita_handler: true do
           { title: 'Test1', number: 42, html_url: 'xxx', user: { login: 'theckman' } }
         ]
         octo_obj = double('Octokit::Client', pull_requests: pr)
-        allow(github_pr).to receive(:octo).and_return(octo_obj)
+        allow_any_instance_of(Lita::Handlers::GithubPR).to receive(:octo).and_return(octo_obj)
       end
 
       it 'should return the list of ten oldest & ten newest' do

--- a/spec/unit/lita/handlers/github_repo_spec.rb
+++ b/spec/unit/lita/handlers/github_repo_spec.rb
@@ -562,10 +562,10 @@ describe Lita::Handlers::GithubRepo, lita_handler: true do
       conf_obj = double('Lita::Configuration', default_org: 'GrapeDuty')
       @response = double('Lita::Response', match_data: match_data)
       @octo_obj = double('Octokit::Client', edit_repository: { description: 'oh hello' })
-      allow(github_repo).to receive(:config).and_return(conf_obj)
-      allow(github_repo).to receive(:octo).and_return(@octo_obj)
-      allow(github_repo).to receive(:func_disabled?).and_return(false)
-      allow(github_repo).to receive(:repo?).and_return(true)
+      allow_any_instance_of(Lita::Handlers::GithubRepo).to receive(:config).and_return(conf_obj)
+      allow_any_instance_of(Lita::Handlers::GithubRepo).to receive(:func_disabled?).and_return(false)
+      allow_any_instance_of(Lita::Handlers::GithubRepo).to receive(:repo?).and_return(true)
+      allow_any_instance_of(Lita::Handlers::GithubRepo).to receive(:octo).and_return(@octo_obj)
     end
 
     context 'when valid inputs provided, and all things work out' do
@@ -576,7 +576,9 @@ describe Lita::Handlers::GithubRepo, lita_handler: true do
     end
 
     context 'when function disabled' do
-      before { allow(github_repo).to receive(:func_disabled?).and_return(true) }
+      before do
+        allow_any_instance_of(Lita::Handlers::GithubRepo).to receive(:func_disabled?).and_return(true)
+      end
 
       it 'should return the method disabled error' do
         send_command('gh repo update description lita-test A new description!')
@@ -585,7 +587,9 @@ describe Lita::Handlers::GithubRepo, lita_handler: true do
     end
 
     context 'when repo not found' do
-      before { allow(github_repo).to receive(:repo?).and_return(false) }
+      before do
+        allow_any_instance_of(Lita::Handlers::GithubRepo).to receive(:repo?).and_return(false)
+      end
 
       it 'should return the repo not found error' do
         send_command('gh repo update description lita-test A new description!')
@@ -612,10 +616,10 @@ describe Lita::Handlers::GithubRepo, lita_handler: true do
       conf_obj = double('Lita::Configuration', default_org: 'GrapeDuty')
       @response = double('Lita::Response', match_data: match_data)
       @octo_obj = double('Octokit::Client', edit_repository: { homepage: 'https://test.it' })
-      allow(github_repo).to receive(:config).and_return(conf_obj)
-      allow(github_repo).to receive(:octo).and_return(@octo_obj)
-      allow(github_repo).to receive(:func_disabled?).and_return(false)
-      allow(github_repo).to receive(:repo?).and_return(true)
+      allow_any_instance_of(Lita::Handlers::GithubRepo).to receive(:config).and_return(conf_obj)
+      allow_any_instance_of(Lita::Handlers::GithubRepo).to receive(:octo).and_return(@octo_obj)
+      allow_any_instance_of(Lita::Handlers::GithubRepo).to receive(:func_disabled?).and_return(false)
+      allow_any_instance_of(Lita::Handlers::GithubRepo).to receive(:repo?).and_return(true)
     end
 
     context 'when valid inputs provided, and all things work out' do
@@ -626,7 +630,9 @@ describe Lita::Handlers::GithubRepo, lita_handler: true do
     end
 
     context 'when function disabled' do
-      before { allow(github_repo).to receive(:func_disabled?).and_return(true) }
+      before do
+        allow_any_instance_of(Lita::Handlers::GithubRepo).to receive(:func_disabled?).and_return(true)
+      end
 
       it 'should return the method disabled error' do
         send_command('gh repo update homepage lita-test https://test.it')
@@ -635,7 +641,9 @@ describe Lita::Handlers::GithubRepo, lita_handler: true do
     end
 
     context 'when repo not found' do
-      before { allow(github_repo).to receive(:repo?).and_return(false) }
+      before do
+        allow_any_instance_of(Lita::Handlers::GithubRepo).to receive(:repo?).and_return(false)
+      end
 
       it 'should return the repo not found error' do
         send_command('gh repo update homepage lita-test https://test.it')
@@ -685,7 +693,7 @@ describe Lita::Handlers::GithubRepo, lita_handler: true do
       }
       pr = [nil, nil, nil, nil, nil]
       @octo_obj = double('Octokit::Client', repository: repo, pull_requests: pr)
-      allow(github_repo).to receive(:octo).and_return(@octo_obj)
+      allow_any_instance_of(Lita::Handlers::GithubRepo).to receive(:octo).and_return(@octo_obj)
     end
 
     it 'should return some repo info' do
@@ -699,9 +707,9 @@ describe Lita::Handlers::GithubRepo, lita_handler: true do
 
   describe '.repo_delete' do
     before do
-      allow(github_repo).to receive(:func_disabled?).and_return(false)
-      allow(github_repo).to receive(:delete_repo).and_return('hello there')
-      allow(github_repo).to receive(:repo?).with("#{github_org}/lita-test").and_return(true)
+      allow_any_instance_of(Lita::Handlers::GithubRepo).to receive(:func_disabled?).and_return(false)
+      allow_any_instance_of(Lita::Handlers::GithubRepo).to receive(:delete_repo).and_return('hello there')
+      allow_any_instance_of(Lita::Handlers::GithubRepo).to receive(:repo?).with("#{github_org}/lita-test").and_return(true)
     end
 
     it 'reply with the return from delete_repo()' do
@@ -711,7 +719,7 @@ describe Lita::Handlers::GithubRepo, lita_handler: true do
 
     context 'when command disabled' do
       before do
-        allow(github_repo).to receive(:func_disabled?).and_return(true)
+        allow_any_instance_of(Lita::Handlers::GithubRepo).to receive(:func_disabled?).and_return(true)
       end
 
       it 'should no-op and say such if the command is disabled' do
@@ -722,7 +730,7 @@ describe Lita::Handlers::GithubRepo, lita_handler: true do
 
     context 'when repo not found' do
       before do
-        allow(github_repo).to receive(:repo?).with("#{github_org}/lita-test").and_return(false)
+        allow_any_instance_of(Lita::Handlers::GithubRepo).to receive(:repo?).with("#{github_org}/lita-test").and_return(false)
       end
 
       it 'should no-op informing you that the repo is not there' do
@@ -735,15 +743,15 @@ describe Lita::Handlers::GithubRepo, lita_handler: true do
   describe '.repo_create' do
     before do
       @opts = { private: true, team_id: 42, organization: github_org }
-      allow(github_repo).to receive(:func_disabled?).and_return(false)
-      allow(github_repo).to receive(:repo?).with("#{github_org}/lita-test").and_return(false)
-      allow(github_repo).to receive(:extrapolate_create_opts).and_return(@opts)
-      allow(github_repo).to receive(:create_repo).and_return('hello from PAX prime!')
+      allow_any_instance_of(Lita::Handlers::GithubRepo).to receive(:func_disabled?).and_return(false)
+      allow_any_instance_of(Lita::Handlers::GithubRepo).to receive(:repo?).with("#{github_org}/lita-test").and_return(false)
+      allow_any_instance_of(Lita::Handlers::GithubRepo).to receive(:extrapolate_create_opts).and_return(@opts)
+      allow_any_instance_of(Lita::Handlers::GithubRepo).to receive(:create_repo).and_return('hello from PAX prime!')
     end
 
     context 'when command disabled' do
       before do
-        allow(github_repo).to receive(:func_disabled?).and_return(true)
+        allow_any_instance_of(Lita::Handlers::GithubRepo).to receive(:func_disabled?).and_return(true)
       end
 
       it 'should no-op and say such if the command is disabled' do
@@ -754,7 +762,7 @@ describe Lita::Handlers::GithubRepo, lita_handler: true do
 
     context 'when repo already exists' do
       before do
-        allow(github_repo).to receive(:repo?).with("#{github_org}/lita-test").and_return(true)
+        allow_any_instance_of(Lita::Handlers::GithubRepo).to receive(:repo?).with("#{github_org}/lita-test").and_return(true)
       end
 
       it 'should tell you it already exists' do
@@ -765,11 +773,11 @@ describe Lita::Handlers::GithubRepo, lita_handler: true do
 
     context 'when repo does not exist' do
       before do
-        allow(github_repo).to receive(:repo?).with("#{github_org}/lita-test").and_return(false)
+        allow_any_instance_of(Lita::Handlers::GithubRepo).to receive(:repo?).with("#{github_org}/lita-test").and_return(false)
       end
 
       it 'should reply with the return of create_repo()' do
-        expect(github_repo).to receive(:extrapolate_create_opts).and_return(@opts)
+        expect_any_instance_of(Lita::Handlers::GithubRepo).to receive(:extrapolate_create_opts).and_return(@opts)
         send_command("gh repo create #{github_org}/lita-test")
         expect(replies.last).to eql 'hello from PAX prime!'
       end
@@ -778,9 +786,9 @@ describe Lita::Handlers::GithubRepo, lita_handler: true do
 
   describe '.repo_rename' do
     before do
-      allow(github_repo).to receive(:func_disabled?).and_return(false)
-      allow(github_repo).to receive(:rename_repo).and_return('hello there')
-      allow(github_repo).to receive(:repo?).with("#{github_org}/lita-test").and_return(true)
+      allow_any_instance_of(Lita::Handlers::GithubRepo).to receive(:func_disabled?).and_return(false)
+      allow_any_instance_of(Lita::Handlers::GithubRepo).to receive(:rename_repo).and_return('hello there')
+      allow_any_instance_of(Lita::Handlers::GithubRepo).to receive(:repo?).with("#{github_org}/lita-test").and_return(true)
     end
 
     it 'reply with the return from rename_repo()' do
@@ -790,7 +798,7 @@ describe Lita::Handlers::GithubRepo, lita_handler: true do
 
     context 'when command disabled' do
       before do
-        allow(github_repo).to receive(:func_disabled?).and_return(true)
+        allow_any_instance_of(Lita::Handlers::GithubRepo).to receive(:func_disabled?).and_return(true)
       end
 
       it 'should no-op and say such if the command is disabled' do
@@ -801,7 +809,7 @@ describe Lita::Handlers::GithubRepo, lita_handler: true do
 
     context 'when repo not found' do
       before do
-        allow(github_repo).to receive(:repo?).with("#{github_org}/lita-test").and_return(false)
+        allow_any_instance_of(Lita::Handlers::GithubRepo).to receive(:repo?).with("#{github_org}/lita-test").and_return(false)
       end
 
       it 'should no-op informing you that the repo is not there' do
@@ -818,7 +826,7 @@ describe Lita::Handlers::GithubRepo, lita_handler: true do
         { name: 'Everyone', slug: 'everyone', id: 42, permission: 'push' }
       ]
       @octo_obj = double('Octokit::Client', repository_teams: @teams)
-      allow(github_repo).to receive(:octo).and_return(@octo_obj)
+      allow_any_instance_of(Lita::Handlers::GithubRepo).to receive(:octo).and_return(@octo_obj)
     end
 
     context 'when it finds a repo' do
@@ -853,11 +861,11 @@ Name: Interns, Slug: interns, ID: 84, Perms: pull
 
   describe '.repo_team_router' do
     before do
-      allow(github_repo).to receive(:repo_team_add).with(an_instance_of(Lita::Response)).and_return('ohai')
+      allow_any_instance_of(Lita::Handlers::GithubRepo).to receive(:repo_team_add).with(an_instance_of(Lita::Response)).and_return('ohai')
     end
 
     it 'should call the method based on action and respond with its return' do
-      expect(github_repo).to receive(:repo_team_add).with(an_instance_of(Lita::Response)).and_return('ohai')
+      expect_any_instance_of(Lita::Handlers::GithubRepo).to receive(:repo_team_add).with(an_instance_of(Lita::Response)).and_return('ohai')
       send_command("gh repo team add 42 #{github_org}/lita-test")
       expect(replies.last).to eql 'ohai'
     end
@@ -865,11 +873,11 @@ Name: Interns, Slug: interns, ID: 84, Perms: pull
 
   describe '.repo_update_router' do
     before do
-      allow(github_repo).to receive(:repo_update_description).with(an_instance_of(Lita::Response)).and_return('ohai')
+      allow_any_instance_of(Lita::Handlers::GithubRepo).to receive(:repo_update_description).with(an_instance_of(Lita::Response)).and_return('ohai')
     end
 
     it 'should call the method based on the action and respond with its return' do
-      expect(github_repo).to receive(:repo_update_description).with(an_instance_of(Lita::Response)).and_return('ohai')
+      expect_any_instance_of(Lita::Handlers::GithubRepo).to receive(:repo_update_description).with(an_instance_of(Lita::Response)).and_return('ohai')
       send_command("gh repo update description #{github_org}/lita-test Something funky here")
       expect(replies.last).to eql 'ohai'
     end

--- a/spec/unit/lita/handlers/github_spec.rb
+++ b/spec/unit/lita/handlers/github_spec.rb
@@ -300,7 +300,7 @@ Following: 20, Followers: 10, Joined: 2011-05-14 04:16:33 UTC'
     before do
       @secret = 'GZSDEMLDMY3TQYLG'
       conf_obj = double('Lita::Configuration', totp_secret: @secret)
-      allow(github).to receive(:config).and_return(conf_obj)
+      allow_any_instance_of(Lita::Handlers::Github).to receive(:config).and_return(conf_obj)
     end
 
     context 'when token is set' do
@@ -314,7 +314,7 @@ Following: 20, Followers: 10, Joined: 2011-05-14 04:16:33 UTC'
     context 'when token is not set' do
       before do
         conf_obj = double('Lita::Configuration', totp_secret: nil)
-        allow(github).to receive(:config).and_return(conf_obj)
+        allow_any_instance_of(Lita::Handlers::Github).to receive(:config).and_return(conf_obj)
       end
 
       it 'should return the error message' do
@@ -344,15 +344,15 @@ Following: 20, Followers: 10, Joined: 2011-05-14 04:16:33 UTC'
       }
       @orgs = [{ login: 'PagerDuty' }, { login: 'GrapeDuty' }]
       @octo_obj = double('Octokit::Client', user: @user_obj, organizations: @orgs)
-      allow(github).to receive(:octo).and_return(@octo_obj)
-      allow(github).to receive(:whois_reply).and_return('StubbedResponse')
+      allow_any_instance_of(Lita::Handlers::Github).to receive(:octo).and_return(@octo_obj)
+      allow_any_instance_of(Lita::Handlers::Github).to receive(:whois_reply).and_return('StubbedResponse')
     end
 
     context 'when all goes well' do
       it 'should return the response from whois_reply' do
         expect(@octo_obj).to receive(:user).with('theckman').and_return(@user_obj)
         expect(@octo_obj).to receive(:organizations).with('theckman').and_return(@orgs)
-        expect(github).to receive(:whois_reply).with(@user_obj, %w(PagerDuty GrapeDuty)).and_return('StubbedResponse')
+        allow_any_instance_of(Lita::Handlers::Github).to receive(:whois_reply).with(@user_obj, %w(PagerDuty GrapeDuty)).and_return('StubbedResponse')
         send_command('gh whois theckman')
         expect(replies.last).to eql 'StubbedResponse'
       end


### PR DESCRIPTION
I've admittedly not done much investigation about where / what introduced this change in behavior. However, for some reason stubs that worked previously stopped working with a fresh bundle install. This updates all of the broken stubs to be valid, thus allowing the tests to pass.

There were no changes to the code used by Lita as this only fixes broken specs.

@tristaneuan 