### PR TITLE
[DEV-328] Allow additional specified teams to be added to a new repo …

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,10 @@ The configuration options will get their own in-depth doc a little further down 
   * This is an administrative utility, so the token will need pretty wide access to leverage this plugin fully
 * `config.handlers.github.default_org = ''`
   * Your company may only have one organization, the handler will allow you to type just the repo name (`lita-github`) instead of `PagerDuty/lita-github`.
-* One of the following options, but not both:
-  * `config.handlers.github.default_team_slug = ''`
-    * if no team is provided when adding a repo, it uses this team by default -- if unset, only owners can access repo
-    * the default team that should be added to a repo based on the slug name:
+  * `config.handlers.github.default_team_slugs = ['']`
+    * if no team is provided when adding a repo, it uses these teams by default -- if unset, only owners can access repo
+    * the default teams that should be added to a repo based on the slug name:
       * When clicking on a team in your org you can use the URL to get the slug: https://github.com/orgs/<ORG>/teams/[slug]
-  * `config.handlers.github.default_team_slugs = []`
-    * With an array of slugs, you can specify multiple teams to be added by default whenever a repo is created
 
 Commands
 --------

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Configuration
 The configuration options will get their own in-depth doc a little further down the line. Here are the important ones for now:
 
 * `config.handlers.github.access_token = ''`
-  * Your GitHUb access token (generated from Settings > Security > Personal Applications)
+  * Your GitHub access token (generated from Settings > Security > Personal Applications)
   * This is an administrative utility, so the token will need pretty wide access to leverage this plugin fully
 * `config.handlers.github.default_org = ''`
   * Your company may only have one organization, the handler will allow you to type just the repo name (`lita-github`) instead of `PagerDuty/lita-github`.
@@ -30,6 +30,8 @@ The configuration options will get their own in-depth doc a little further down 
   * if no team is provided when adding a repo, it uses this team by default -- if unset, only owners can access repo
   * the default team that should be added to a repo based on the slug name:
     * When clicking on a team in your org you can use the URL to get the slug: https://github.com/orgs/<ORG>/teams/[slug]
+* `config.handlers.github.additional_default_teams = []`
+  * With an array of slugs, you can specify additional teams to be added by default whenever a repo is created
 
 Commands
 --------

--- a/README.md
+++ b/README.md
@@ -26,12 +26,13 @@ The configuration options will get their own in-depth doc a little further down 
   * This is an administrative utility, so the token will need pretty wide access to leverage this plugin fully
 * `config.handlers.github.default_org = ''`
   * Your company may only have one organization, the handler will allow you to type just the repo name (`lita-github`) instead of `PagerDuty/lita-github`.
-* `config.handlers.github.default_team_slug = ''`
-  * if no team is provided when adding a repo, it uses this team by default -- if unset, only owners can access repo
-  * the default team that should be added to a repo based on the slug name:
-    * When clicking on a team in your org you can use the URL to get the slug: https://github.com/orgs/<ORG>/teams/[slug]
-* `config.handlers.github.additional_default_teams = []`
-  * With an array of slugs, you can specify additional teams to be added by default whenever a repo is created
+* One of the following options, but not both:
+  * `config.handlers.github.default_team_slug = ''`
+    * if no team is provided when adding a repo, it uses this team by default -- if unset, only owners can access repo
+    * the default team that should be added to a repo based on the slug name:
+      * When clicking on a team in your org you can use the URL to get the slug: https://github.com/orgs/<ORG>/teams/[slug]
+  * `config.handlers.github.default_team_slugs = []`
+    * With an array of slugs, you can specify multiple teams to be added by default whenever a repo is created
 
 Commands
 --------

--- a/lib/lita/handlers/github.rb
+++ b/lib/lita/handlers/github.rb
@@ -69,7 +69,7 @@ module Lita
         # when setting default configuration values please remember one thing:
         # secure and safe by default
         config.default_team_slug          = nil
-        config.additional_default_teams   = []
+        config.default_team_slugs         = nil
         config.repo_private_default       = true
         config.org_team_add_allowed_perms = %w(pull)
 

--- a/lib/lita/handlers/github.rb
+++ b/lib/lita/handlers/github.rb
@@ -68,7 +68,6 @@ module Lita
       def self.default_config(config)
         # when setting default configuration values please remember one thing:
         # secure and safe by default
-        config.default_team_slug          = nil
         config.default_team_slugs         = nil
         config.repo_private_default       = true
         config.org_team_add_allowed_perms = %w(pull)

--- a/lib/lita/handlers/github.rb
+++ b/lib/lita/handlers/github.rb
@@ -69,6 +69,7 @@ module Lita
         # when setting default configuration values please remember one thing:
         # secure and safe by default
         config.default_team_slug          = nil
+        config.additional_default_teams   = []
         config.repo_private_default       = true
         config.org_team_add_allowed_perms = %w(pull)
 

--- a/lib/lita/handlers/github_repo.rb
+++ b/lib/lita/handlers/github_repo.rb
@@ -300,11 +300,9 @@ module Lita
       # rubocop:enable Metrics/PerceivedComplexity
 
       def default_teams(org)
-        # If default_team_slug is defined, return it as the sole element in an array
-        return [team_id_by_slug(config.default_team_slug, org)] unless config.default_team_slug.nil?
-        # Otherwise, look at default_team_slugs
         teams = config.default_team_slugs
-        # If it's either a non-array or an empty array, return an array containing nil
+        # If default_team_slugs is either a non-array (e.g. nil) or an empty
+        # array, return an array containing nil
         return [nil] if !teams.is_a?(Array) || teams.empty?
         # If it's a populated array, return an array of corresponding team IDs
         teams.map { |team| team_id_by_slug(team, org) }

--- a/lib/lita/handlers/github_repo.rb
+++ b/lib/lita/handlers/github_repo.rb
@@ -277,7 +277,7 @@ module Lita
       def extrapolate_create_opts(opts, org)
         opts[:organization] = org
 
-        first_team, other_teams = filter_teams default_teams(org)
+        first_team, other_teams = filter_teams(default_teams(org))
 
         begin
           t_id = team_id_by_slug(opts.fetch(:team), org)

--- a/lib/lita/handlers/github_repo.rb
+++ b/lib/lita/handlers/github_repo.rb
@@ -294,6 +294,10 @@ module Lita
         config.default_team_slug.nil? ? nil : team_id_by_slug(config.default_team_slug, org)
       end
 
+      def additional_teams(org)
+        config.additional_default_teams.map { |team| team_id_by_slug(team, org) }
+      end
+
       def should_repo_be_private?(value)
         if value.nil? || value.empty?
           config.repo_private_default
@@ -308,7 +312,7 @@ module Lita
           true
         when 'false'
           false
-        else # when some invalud value...
+        else # when some invalid value...
           config.repo_private_default
         end
       end
@@ -318,6 +322,9 @@ module Lita
         reply = nil
         begin
           octo.create_repository(repo, opts)
+          additional_teams(org).each do |team|
+            add_team_to_repo(full_name, team)
+          end
         ensure
           if repo?(full_name)
             repo_url = "https://github.com/#{full_name}"

--- a/spec/unit/lita/handlers/github_repo_spec.rb
+++ b/spec/unit/lita/handlers/github_repo_spec.rb
@@ -133,9 +133,9 @@ describe Lita::Handlers::GithubRepo, lita_handler: true do
       allow(github_repo).to receive(:team_id_by_slug).and_return(88)
     end
 
-    context 'when default_team_slug is set' do
+    context 'when default_team_slugs is set' do
       before do
-        cfg_obj = double('Lita::Configuration', default_team_slug: 'heckman')
+        cfg_obj = double('Lita::Configuration', default_team_slugs: ['heckman'])
         allow(github_repo).to receive(:config).and_return(cfg_obj)
       end
 
@@ -146,74 +146,49 @@ describe Lita::Handlers::GithubRepo, lita_handler: true do
       end
     end
 
-    context 'when default_team_slug is not set' do
-      context 'when default_team_slugs is not set' do
-        before do
-          cfg_obj = double(
-            'Lita::Configuration', default_team_slug: nil, default_team_slugs: nil)
-          allow(github_repo).to receive(:config).and_return(cfg_obj)
-        end
-
-        it 'should return [nil]' do
-          expect(github_repo.send(:default_teams, github_org)).to eql [nil]
-        end
+    context 'when default_team_slugs is not set' do
+      before do
+        cfg_obj = double('Lita::Configuration', default_team_slugs: nil)
+        allow(github_repo).to receive(:config).and_return(cfg_obj)
       end
 
-      context 'when default_team_slugs is an empty array' do
-        before do
-          cfg_obj = double(
-            'Lita::Configuration', default_team_slug: nil, default_team_slugs: [])
-          allow(github_repo).to receive(:config).and_return(cfg_obj)
-        end
+      it 'should return [nil]' do
+        expect(github_repo.send(:default_teams, github_org)).to eql [nil]
+      end
+    end
 
-        it 'should return [nil]' do
-          expect(github_repo.send(:default_teams, github_org)).to eql [nil]
-        end
+    context 'when default_team_slugs is an empty array' do
+      before do
+        cfg_obj = double('Lita::Configuration', default_team_slugs: [])
+        allow(github_repo).to receive(:config).and_return(cfg_obj)
       end
 
-      context 'when default_team_slugs is set to an array with 1 element' do
-        before do
-          cfg_obj = double(
-            'Lita::Configuration',
-            default_team_slug: nil,
-            default_team_slugs: ['heckman']
-          )
-          allow(github_repo).to receive(:config).and_return(cfg_obj)
-        end
+      it 'should return [nil]' do
+        expect(github_repo.send(:default_teams, github_org)).to eql [nil]
+      end
+    end
 
-        it 'should return an array containing the corresponding team ID' do
-          expect(github_repo).to receive(:team_id_by_slug).with('heckman', 'GrapeDuty')
-            .and_return(42)
-          expect(github_repo.send(:default_teams, github_org)).to eql [42]
-        end
+    context 'when default_team_slugs is set to an array with multiple elements' do
+      before do
+        cfg_obj = double('Lita::Configuration', default_team_slugs: %w(heckman orwell))
+        allow(github_repo).to receive(:config).and_return(cfg_obj)
       end
 
-      context 'when default_team_slugs is set to an array with multiple elements' do
-        before do
-          cfg_obj = double(
-            'Lita::Configuration',
-            default_team_slug: nil,
-            default_team_slugs: %w(heckman orwell)
-          )
-          allow(github_repo).to receive(:config).and_return(cfg_obj)
-        end
-
-        it 'should return an array containing the corresponding team IDs' do
-          expect(github_repo).to receive(:team_id_by_slug).with('heckman', 'GrapeDuty')
-            .and_return(42)
-          expect(github_repo).to receive(:team_id_by_slug).with('orwell', 'GrapeDuty')
-            .and_return(84)
-          expect(github_repo.send(:default_teams, github_org)).to eql [42, 84]
-        end
+      it 'should return an array containing the corresponding team IDs' do
+        expect(github_repo).to receive(:team_id_by_slug).with('heckman', 'GrapeDuty')
+          .and_return(42)
+        expect(github_repo).to receive(:team_id_by_slug).with('orwell', 'GrapeDuty')
+          .and_return(84)
+        expect(github_repo.send(:default_teams, github_org)).to eql [42, 84]
       end
     end
   end
 
   describe '.extrapolate_create_opts' do
-    context 'when default_team_slug is set' do
+    context 'when default_team_slugs is set' do
       before do
         @eco_opts = {}
-        @c_obj = double('Lita::Configuration', default_team_slug: 'h3ckman')
+        @c_obj = double('Lita::Configuration', default_team_slugs: ['h3ckman'])
         allow(github_repo).to receive(:config).and_return(@c_obj)
         allow(github_repo).to receive(:team_id_by_slug).and_return(42)
         allow(github_repo).to receive(:should_repo_be_private?).and_return(true)
@@ -242,7 +217,7 @@ describe Lita::Handlers::GithubRepo, lita_handler: true do
 
         context 'when default_teams returns [nil]' do
           before do
-            @c_obj = double('Lita::Configuration', default_team_slug: nil)
+            @c_obj = double('Lita::Configuration', default_team_slugs: nil)
             allow(github_repo).to receive(:config).and_return(@c_obj)
           end
 
@@ -277,7 +252,7 @@ describe Lita::Handlers::GithubRepo, lita_handler: true do
           context 'when there is no default slug set' do
             before do
               @eco_opts = { team: 'h3ckman', private: true }
-              c_obj = double('Lita::Configuration', default_team_slug: nil, default_team_slugs: nil)
+              c_obj = double('Lita::Configuration', default_team_slugs: nil)
               allow(github_repo).to receive(:config).and_return(c_obj)
             end
 

--- a/spec/unit/lita/handlers/github_repo_spec.rb
+++ b/spec/unit/lita/handlers/github_repo_spec.rb
@@ -128,157 +128,233 @@ describe Lita::Handlers::GithubRepo, lita_handler: true do
     end
   end
 
-  describe '.default_team' do
+  describe '.default_teams' do
     before do
       allow(github_repo).to receive(:team_id_by_slug).and_return(88)
     end
 
-    context 'when the default team slug is set' do
+    context 'when default_team_slug is set' do
       before do
         cfg_obj = double('Lita::Configuration', default_team_slug: 'heckman')
         allow(github_repo).to receive(:config).and_return(cfg_obj)
       end
 
-      it 'should return the team ID of the slug' do
+      it 'should return an array containing the team ID of the slug' do
         expect(github_repo).to receive(:team_id_by_slug).with('heckman', 'GrapeDuty')
           .and_return(42)
-        expect(github_repo.send(:default_team, github_org)).to eql 42
+        expect(github_repo.send(:default_teams, github_org)).to eql [42]
       end
     end
 
-    context 'when the default slug is not set' do
-      before do
-        cfg_obj = double('Lita::Configuration', default_team_slug: nil)
-        allow(github_repo).to receive(:config).and_return(cfg_obj)
+    context 'when default_team_slug is not set' do
+      context 'when default_team_slugs is not set' do
+        before do
+          cfg_obj = double(
+            'Lita::Configuration', default_team_slug: nil, default_team_slugs: nil)
+          allow(github_repo).to receive(:config).and_return(cfg_obj)
+        end
+
+        it 'should return [nil]' do
+          expect(github_repo.send(:default_teams, github_org)).to eql [nil]
+        end
       end
 
-      it 'should return nil' do
-        expect(github_repo.send(:default_team, github_org)).to be_nil
-      end
-    end
-  end
+      context 'when default_team_slugs is an empty array' do
+        before do
+          cfg_obj = double(
+            'Lita::Configuration', default_team_slug: nil, default_team_slugs: [])
+          allow(github_repo).to receive(:config).and_return(cfg_obj)
+        end
 
-  describe '.additional_teams' do
-    before do
-      allow(github_repo).to receive(:team_id_by_slug).and_return(88)
-    end
-
-    context 'when the additional_default_teams config option is set' do
-      before do
-        cfg_obj = double('Lita::Configuration', additional_default_teams: ['heckman', 'orwell'])
-        allow(github_repo).to receive(:config).and_return(cfg_obj)
+        it 'should return [nil]' do
+          expect(github_repo.send(:default_teams, github_org)).to eql [nil]
+        end
       end
 
-      it 'should return an array of team IDs' do
-        expect(github_repo).to receive(:team_id_by_slug).with('heckman', 'GrapeDuty')
-          .and_return(42)
-        expect(github_repo).to receive(:team_id_by_slug).with('orwell', 'GrapeDuty')
-          .and_return(84)
-        expect(github_repo.send(:additional_teams, github_org)).to eql [42, 84]
-      end
-    end
+      context 'when default_team_slugs is set to an array with 1 element' do
+        before do
+          cfg_obj = double(
+            'Lita::Configuration',
+            default_team_slug: nil,
+            default_team_slugs: ['heckman']
+          )
+          allow(github_repo).to receive(:config).and_return(cfg_obj)
+        end
 
-    context 'when the additional_default_teams config option is not set' do
-      before do
-        cfg_obj = double('Lita::Configuration', additional_default_teams: [])
-        allow(github_repo).to receive(:config).and_return(cfg_obj)
+        it 'should return an array containing the corresponding team ID' do
+          expect(github_repo).to receive(:team_id_by_slug).with('heckman', 'GrapeDuty')
+            .and_return(42)
+          expect(github_repo.send(:default_teams, github_org)).to eql [42]
+        end
       end
 
-      it 'should return an empty array' do
-        expect(github_repo.send(:additional_teams, github_org)).to eql []
+      context 'when default_team_slugs is set to an array with multiple elements' do
+        before do
+          cfg_obj = double(
+            'Lita::Configuration',
+            default_team_slug: nil,
+            default_team_slugs: %w(heckman orwell)
+          )
+          allow(github_repo).to receive(:config).and_return(cfg_obj)
+        end
+
+        it 'should return an array containing the corresponding team IDs' do
+          expect(github_repo).to receive(:team_id_by_slug).with('heckman', 'GrapeDuty')
+            .and_return(42)
+          expect(github_repo).to receive(:team_id_by_slug).with('orwell', 'GrapeDuty')
+            .and_return(84)
+          expect(github_repo.send(:default_teams, github_org)).to eql [42, 84]
+        end
       end
     end
   end
 
   describe '.extrapolate_create_opts' do
-    before do
-      @eco_opts = {}
-      @c_obj = double('Lita::Configuration', default_team_slug: 'h3ckman')
-      allow(github_repo).to receive(:config).and_return(@c_obj)
-      allow(github_repo).to receive(:team_id_by_slug).and_return(42)
-      allow(github_repo).to receive(:should_repo_be_private?).and_return(true)
-    end
-
-    it 'should set the :organization key, :team_id key, and :private key' do
-      h = { organization: github_org, team_id: 42, private: true }
-      expect(github_repo.send(:extrapolate_create_opts, @eco_opts, github_org)).to eql h
-    end
-
-    it 'should set the private key to the return of should_repo_be_private?' do
-      opts = { private: 'test', team_id: 42 }
-      expect(github_repo).to receive(:should_repo_be_private?).with('test').and_return :ohai
-      r = github_repo.send(:extrapolate_create_opts, opts, github_org)
-      expect(r[:private]).to eql :ohai
-    end
-
-    context 'when there is no :team set' do
-      context 'when default_team returns a team id' do
-        it 'should get the default team_id' do
-          h = { organization: github_org, team_id: 44, private: true }
-          expect(github_repo).to receive(:default_team).with(github_org).and_return(44)
-          expect(github_repo.send(:extrapolate_create_opts, @eco_opts, github_org)).to eql h
-        end
+    context 'when default_team_slug is set' do
+      before do
+        @eco_opts = {}
+        @c_obj = double('Lita::Configuration', default_team_slug: 'h3ckman')
+        allow(github_repo).to receive(:config).and_return(@c_obj)
+        allow(github_repo).to receive(:team_id_by_slug).and_return(42)
+        allow(github_repo).to receive(:should_repo_be_private?).and_return(true)
       end
 
-      context 'when default_team returns nil' do
-        before do
-          @c_obj = double('Lita::Configuration', default_team_slug: nil)
-          allow(github_repo).to receive(:config).and_return(@c_obj)
-        end
-
-        it 'should not set the :team_id key' do
-          h = { organization: github_org, private: true }
-          expect(github_repo).to receive(:default_team).with(github_org).and_return(nil)
-          expect(github_repo.send(:extrapolate_create_opts, @eco_opts, github_org)).to eql h
-        end
-      end
-    end
-
-    context 'when options contains :team and no :team_id' do
-      context 'when given a valid slug' do
-        before { @eco_opts = { team: 'heckman' } }
-
-        it 'should set the :team_id key' do
-          h = { organization: github_org, team_id: 84, private: true }.merge!(@eco_opts)
-          expect(github_repo).to receive(:team_id_by_slug).with('heckman', github_org).and_return(84)
-          expect(github_repo.send(:extrapolate_create_opts, @eco_opts, github_org)).to eql h
-        end
-      end
-
-      context 'when given an invalid slug' do
-        context 'when there is a default slug set' do
-          it 'should set the team to the default' do
-            h = { organization: github_org, team_id: 42, private: true }.merge!(@eco_opts)
-            expect(github_repo).to receive(:team_id_by_slug).with('h3ckman', github_org).and_return(42)
-            expect(github_repo.send(:extrapolate_create_opts, @eco_opts, github_org)).to eql h
-          end
-        end
-
-        context 'when there is no default slug set' do
-          before do
-            @eco_opts = { team: 'h3ckman', private: true }
-            c_obj = double('Lita::Configuration', default_team_slug: nil)
-            allow(github_repo).to receive(:config).and_return(c_obj)
-          end
-
-          it 'should not set a :team_id' do
-            h = { organization: github_org }.merge!(@eco_opts)
-            expect(github_repo).to receive(:team_id_by_slug).with('h3ckman', github_org)
-              .and_return(nil)
-            expect(github_repo).to receive(:default_team).with(github_org).and_call_original
-            expect(github_repo.send(:extrapolate_create_opts, @eco_opts, github_org)).to eql h
-          end
-        end
-      end
-    end
-
-    context 'when there is a :team_id key' do
-      before { @eco_opts = { team_id: 44, private: true } }
-
-      it 'should just leave it alone...' do
-        h = { organization: github_org }.merge!(@eco_opts)
-        expect(github_repo).not_to receive(:team_id_by_slug)
+      it 'should set the :organization key, :team_id key, and :private key' do
+        h = { organization: github_org, team_id: 42, private: true }
         expect(github_repo.send(:extrapolate_create_opts, @eco_opts, github_org)).to eql h
+      end
+
+      it 'should set the private key to the return of should_repo_be_private?' do
+        opts = { private: 'test', team_id: 42 }
+        expect(github_repo).to receive(:should_repo_be_private?).with('test').and_return :ohai
+        r = github_repo.send(:extrapolate_create_opts, opts, github_org)
+        expect(r[:private]).to eql :ohai
+      end
+
+      context 'when there is no :team set' do
+        context 'when default_teams returns an array containing a team id' do
+          it 'should get the default team_id' do
+            h = { organization: github_org, team_id: 44, private: true }
+            expect(github_repo).to receive(:default_teams).with(github_org).and_return([44])
+            expect(github_repo.send(:extrapolate_create_opts, @eco_opts, github_org)).to eql h
+          end
+        end
+
+        context 'when default_teams returns [nil]' do
+          before do
+            @c_obj = double('Lita::Configuration', default_team_slug: nil)
+            allow(github_repo).to receive(:config).and_return(@c_obj)
+          end
+
+          it 'should not set the :team_id key' do
+            h = { organization: github_org, private: true }
+            expect(github_repo).to receive(:default_teams).with(github_org).and_return([nil])
+            expect(github_repo.send(:extrapolate_create_opts, @eco_opts, github_org)).to eql h
+          end
+        end
+      end
+
+      context 'when options contains :team and no :team_id' do
+        context 'when given a valid slug' do
+          before { @eco_opts = { team: 'heckman' } }
+
+          it 'should set the :team_id key' do
+            h = { organization: github_org, team_id: 84, private: true }.merge!(@eco_opts)
+            expect(github_repo).to receive(:team_id_by_slug).with('heckman', github_org).and_return(84)
+            expect(github_repo.send(:extrapolate_create_opts, @eco_opts, github_org)).to eql h
+          end
+        end
+
+        context 'when given an invalid slug' do
+          context 'when there is a default slug set' do
+            it 'should set the team to the default' do
+              h = { organization: github_org, team_id: 42, private: true }.merge!(@eco_opts)
+              expect(github_repo).to receive(:team_id_by_slug).with('h3ckman', github_org).and_return(42)
+              expect(github_repo.send(:extrapolate_create_opts, @eco_opts, github_org)).to eql h
+            end
+          end
+
+          context 'when there is no default slug set' do
+            before do
+              @eco_opts = { team: 'h3ckman', private: true }
+              c_obj = double('Lita::Configuration', default_team_slug: nil, default_team_slugs: nil)
+              allow(github_repo).to receive(:config).and_return(c_obj)
+            end
+
+            it 'should not set a :team_id' do
+              h = { organization: github_org }.merge!(@eco_opts)
+              expect(github_repo).to receive(:team_id_by_slug).with('h3ckman', github_org)
+                .and_return(nil)
+              expect(github_repo).to receive(:default_teams).with(github_org).and_call_original
+              expect(github_repo.send(:extrapolate_create_opts, @eco_opts, github_org)).to eql h
+            end
+          end
+        end
+      end
+
+      context 'when there is a :team_id key' do
+        before { @eco_opts = { team_id: 44, private: true } }
+
+        it 'should just leave it alone...' do
+          h = { organization: github_org }.merge!(@eco_opts)
+          expect(github_repo.send(:extrapolate_create_opts, @eco_opts, github_org)).to eql h
+        end
+      end
+    end
+
+    context 'with an array of default teams' do
+      before do
+        allow(github_repo).to receive(:should_repo_be_private?).and_return(true)
+      end
+
+      context 'consisting of a nil element' do
+        before do
+          allow(github_repo).to receive(:default_teams).with(github_org).and_return([nil])
+        end
+
+        it 'does not set :team_id' do
+          expect(github_repo.send(:extrapolate_create_opts, { private: true }, github_org)).to eql(organization: github_org, private: true)
+        end
+      end
+
+      context 'consisting of one valid team ID' do
+        before do
+          allow(github_repo).to receive(:default_teams).with(github_org).and_return([42])
+        end
+
+        it 'sets :team_id' do
+          expect(github_repo.send(:extrapolate_create_opts, { private: true }, github_org)).to eql(organization: github_org, team_id: 42, private: true)
+        end
+      end
+
+      context 'consisting of two valid team IDs' do
+        before do
+          allow(github_repo).to receive(:default_teams).with(github_org).and_return([42, 84])
+        end
+
+        it 'sets :team_id and :other_teams' do
+          expect(github_repo.send(:extrapolate_create_opts, { private: true }, github_org)).to eql(organization: github_org, team_id: 42, other_teams: [84], private: true)
+        end
+      end
+
+      context 'consisting of three valid team IDs' do
+        before do
+          allow(github_repo).to receive(:default_teams).with(github_org).and_return([42, 84, 1])
+        end
+
+        it 'sets :team_id and :other_teams' do
+          expect(github_repo.send(:extrapolate_create_opts, { private: true }, github_org)).to eql(organization: github_org, team_id: 42, other_teams: [84, 1], private: true)
+        end
+      end
+
+      context 'consisting of one valid team ID and one invalid team ID' do
+        before do
+          allow(github_repo).to receive(:default_teams).with(github_org).and_return([42, nil])
+        end
+
+        it 'sets :team_id but not :other_teams' do
+          expect(github_repo.send(:extrapolate_create_opts, { private: true }, github_org)).to eql(organization: github_org, team_id: 42, private: true)
+        end
       end
     end
   end
@@ -299,15 +375,11 @@ describe Lita::Handlers::GithubRepo, lita_handler: true do
           .to eql 'Created GrapeDuty/lita-test: https://github.com/GrapeDuty/lita-test'
       end
 
-      context 'when additional default teams are given' do
-        before do
-          allow(github_repo).to receive(:additional_teams).and_return([42, 84])
-        end
-
+      context 'when other teams are given' do
         it 'should add teams to the repo after creating it' do
           expect(github_repo).to receive(:add_team_to_repo).with('GrapeDuty/lita-test', 42)
           expect(github_repo).to receive(:add_team_to_repo).with('GrapeDuty/lita-test', 84)
-          opts = { private: true, team_id: 1, organization: github_org }
+          opts = { private: true, team_id: 1, other_teams: [42, 84], organization: github_org }
           github_repo.send(:create_repo, github_org, 'lita-test', opts)
         end
       end


### PR DESCRIPTION
…by default

This pull request adds the configuration option
`config.handlers.github.additional_default_teams`
which takes an array of slugs to be added by default whenever a new repo
is created.