### PR TITLE
Fix issue with adding additional teams

### DIFF
--- a/lib/lita/handlers/github_repo.rb
+++ b/lib/lita/handlers/github_repo.rb
@@ -330,8 +330,8 @@ module Lita
         reply = nil
         begin
           octo.create_repository(repo, opts)
-          opts[:other_teams].each do |team|
-            add_team_to_repo(full_name, team)
+          opts[:other_teams].each do |team_id|
+            add_team_to_repo(full_name, gh_team(org, team_id))
           end if opts.key?(:other_teams)
         ensure
           if repo?(full_name)

--- a/spec/unit/lita/handlers/github_repo_spec.rb
+++ b/spec/unit/lita/handlers/github_repo_spec.rb
@@ -336,7 +336,7 @@ describe Lita::Handlers::GithubRepo, lita_handler: true do
 
   describe '.create_repo' do
     before do
-      allow(github_repo).to receive(:octo).and_return(double('Octokit::Client', create_repository: nil))
+      allow(github_repo).to receive(:octo).and_return(double('Octokit::Client', create_repository: nil, team: {}))
     end
 
     context 'when repo created' do

--- a/spec/unit/lita/handlers/github_repo_spec.rb
+++ b/spec/unit/lita/handlers/github_repo_spec.rb
@@ -336,7 +336,10 @@ describe Lita::Handlers::GithubRepo, lita_handler: true do
 
   describe '.create_repo' do
     before do
-      allow(github_repo).to receive(:octo).and_return(double('Octokit::Client', create_repository: nil, team: {}))
+      client = double('Octokit::Client')
+      allow(github_repo).to receive(:octo).and_return(client)
+      allow(client).to receive(:create_repository).and_return(nil)
+      allow(client).to receive(:team).exactly(2).times.and_return({ id: 42, name: 'heckman' }, { id: 84, name: 'orwell' })
     end
 
     context 'when repo created' do
@@ -352,8 +355,8 @@ describe Lita::Handlers::GithubRepo, lita_handler: true do
 
       context 'when other teams are given' do
         it 'should add teams to the repo after creating it' do
-          expect(github_repo).to receive(:add_team_to_repo).with('GrapeDuty/lita-test', 42)
-          expect(github_repo).to receive(:add_team_to_repo).with('GrapeDuty/lita-test', 84)
+          expect(github_repo).to receive(:add_team_to_repo).with('GrapeDuty/lita-test', { id: 42, name: 'heckman' })
+          expect(github_repo).to receive(:add_team_to_repo).with('GrapeDuty/lita-test', { id: 84, name: 'orwell' })
           opts = { private: true, team_id: 1, other_teams: [42, 84], organization: github_org }
           github_repo.send(:create_repo, github_org, 'lita-test', opts)
         end

--- a/spec/unit/lita/handlers/github_repo_spec.rb
+++ b/spec/unit/lita/handlers/github_repo_spec.rb
@@ -336,9 +336,8 @@ describe Lita::Handlers::GithubRepo, lita_handler: true do
 
   describe '.create_repo' do
     before do
-      client = double('Octokit::Client')
+      client = double('Octokit::Client', create_repository: nil)
       allow(github_repo).to receive(:octo).and_return(client)
-      allow(client).to receive(:create_repository).and_return(nil)
       allow(client).to receive(:team).exactly(2).times.and_return({ id: 42, name: 'heckman' }, { id: 84, name: 'orwell' })
     end
 

--- a/spec/unit/lita/handlers/github_repo_spec.rb
+++ b/spec/unit/lita/handlers/github_repo_spec.rb
@@ -358,7 +358,8 @@ describe Lita::Handlers::GithubRepo, lita_handler: true do
           expect(github_repo).to receive(:add_team_to_repo).with('GrapeDuty/lita-test', { id: 42, name: 'heckman' })
           expect(github_repo).to receive(:add_team_to_repo).with('GrapeDuty/lita-test', { id: 84, name: 'orwell' })
           opts = { private: true, team_id: 1, other_teams: [42, 84], organization: github_org }
-          github_repo.send(:create_repo, github_org, 'lita-test', opts)
+          expect(github_repo.send(:create_repo, github_org, 'lita-test', opts))
+            .to eql 'Created GrapeDuty/lita-test: https://github.com/GrapeDuty/lita-test'
         end
       end
     end


### PR DESCRIPTION
It turns out additional teams need to have their full object looked up before being added - this fixes the issue (verified by manually testing), but the testing artifact needs to be fleshed out more.  Raising PR to discuss the best way to do so.