### PR TITLE
Update for lita v5 compatibility

### DIFF
--- a/lib/lita/handlers/github.rb
+++ b/lib/lita/handlers/github.rb
@@ -65,39 +65,39 @@ module Lita
         }
       )
 
-      def self.default_config(config)
-        # when setting default configuration values please remember one thing:
-        # secure and safe by default
-        config.default_team_slugs         = nil
-        config.repo_private_default       = true
-        config.org_team_add_allowed_perms = %w(pull)
+      # when setting default configuration values please remember one thing:
+      # secure and safe by default
+      config :access_token, default: nil
+      config :default_team_slugs, default: nil
+      config :repo_private_default, default: true
+      config :org_team_add_allowed_perms, default: %w(pull)
 
-        ####
-        # Method Filters
-        ####
+      ####
+      # Method Filters
+      ####
 
-        # Lita::Handlers::Github
-        config.totp_secret = nil
+      # Lita::Handlers::Github
+      config :totp_secret, default: nil
 
-        # Lita::Handlers::GithubRepo
-        config.repo_create_enabled              = true
-        config.repo_rename_enabled              = true
-        config.repo_delete_enabled              = false
-        config.repo_team_add_enabled            = false
-        config.repo_team_rm_enabled             = false
-        config.repo_update_description_enabled  = true
-        config.repo_update_homepage_enabled     = true
+      # Lita::Handlers::GithubRepo
+      config :repo_create_enabled, default: true
+      config :repo_rename_enabled, default: true
+      config :repo_delete_enabled, default: false
+      config :repo_team_add_enabled, default: false
+      config :repo_team_rm_enabled, default: false
+      config :repo_update_description_enabled, default: true
+      config :repo_update_homepage_enabled, default: true
 
-        # Lita::Handlers::GithubPR
-        config.pr_merge_enabled = true
+      # Lita::Handlers::GithubPR
+      config :pr_merge_enabled, default: true
 
-        # Lita::Handlers::GithubOrg
-        config.org_team_add_enabled       = false
-        config.org_team_rm_enabled        = false
-        config.org_user_add_enabled       = false
-        config.org_user_rm_enabled        = false
-        config.org_eject_user_enabled     = false
-      end
+      # Lita::Handlers::GithubOrg
+      config :default_org, default: nil
+      config :org_team_add_enabled, default: false
+      config :org_team_rm_enabled, default: false
+      config :org_user_add_enabled, default: false
+      config :org_user_rm_enabled, default: false
+      config :org_eject_user_enabled, default: false
 
       def status(response)
         status = octo.github_status_last_message

--- a/lita-github.gemspec
+++ b/lita-github.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4', '>= 0.4.0'
   s.add_development_dependency 'yard', '~> 0.8.7'
 
-  s.add_runtime_dependency 'lita', '~> 4.0'
+  s.add_runtime_dependency 'lita', '>= 4.0'
   s.add_runtime_dependency 'octokit', '~> 3.3'
   s.add_runtime_dependency 'rotp', '~> 2.0'
   s.add_runtime_dependency 'lita-confirmation'

--- a/spec/unit/lita/handlers/github_issues_spec.rb
+++ b/spec/unit/lita/handlers/github_issues_spec.rb
@@ -27,7 +27,7 @@ describe Lita::Handlers::GithubIssues, lita_handler: true do
 
   let(:gh_org) { 'GapeDuty' }
   let(:gh_repo) { 'lita-test' }
-  let(:github_issues) { Lita::Handlers::GithubIssues.new('robot') }
+  let(:github_issues) { Lita::Handlers::GithubIssues.new(robot) }
 
   describe '.validate_list_opts' do
     let(:good_opts) { { state: 'open', sort: 'updated', direction: 'asc' } }

--- a/spec/unit/lita/handlers/github_org_spec.rb
+++ b/spec/unit/lita/handlers/github_org_spec.rb
@@ -51,7 +51,7 @@ describe Lita::Handlers::GithubOrg, lita_handler: true do
   it { is_expected.to route_command('gh org eject GrapeDuty theckman').to(:org_eject_user) }
   it { is_expected.to route_command('gh org eject theckman').to(:org_eject_user) }
 
-  let(:github_org) { Lita::Handlers::GithubOrg.new('robot') }
+  let(:github_org) { Lita::Handlers::GithubOrg.new(robot) }
   let(:disabled_err) { 'Sorry, this function has either been disabled or not enabled in the config' }
 
   ####

--- a/spec/unit/lita/handlers/github_pr_spec.rb
+++ b/spec/unit/lita/handlers/github_pr_spec.rb
@@ -33,7 +33,7 @@ describe Lita::Handlers::GithubPR, lita_handler: true do
   it { is_expected.to route_command('gh pr list GrapeDuty/lita-test').to(:pr_list) }
   it { is_expected.to route_command('gh pr list lita-test').to(:pr_list) }
 
-  let(:github_pr) { Lita::Handlers::GithubPR.new('robot') }
+  let(:github_pr) { Lita::Handlers::GithubPR.new(robot) }
   let(:github_org) { 'GrapeDuty' }
   let(:github_repo) { 'lita-test' }
   let(:full_name) { "#{github_org}/#{github_repo}" }

--- a/spec/unit/lita/handlers/github_repo_spec.rb
+++ b/spec/unit/lita/handlers/github_repo_spec.rb
@@ -76,7 +76,7 @@ describe Lita::Handlers::GithubRepo, lita_handler: true do
   it { is_expected.to route_command('gh repo update description GrapeDuty/lita-test Some description here').to(:repo_update_router) }
   it { is_expected.to route_command('gh repo update description lita-test Some description here').to(:repo_update_router) }
 
-  let(:github_repo) { Lita::Handlers::GithubRepo.new('robot') }
+  let(:github_repo) { Lita::Handlers::GithubRepo.new(robot) }
   let(:github_org) { 'GrapeDuty' }
   let(:disabled_reply) { 'Sorry, this function has either been disabled or not enabled in the config' }
 

--- a/spec/unit/lita/handlers/github_spec.rb
+++ b/spec/unit/lita/handlers/github_spec.rb
@@ -17,7 +17,7 @@
 require 'spec_helper'
 
 describe Lita::Handlers::Github, lita_handler: true do
-  let(:github) { Lita::Handlers::Github.new('robot') }
+  let(:github) { Lita::Handlers::Github.new(robot) }
 
   # status routing
   it { is_expected.to route_command('gh status').to(:status) }
@@ -33,9 +33,9 @@ describe Lita::Handlers::Github, lita_handler: true do
   it { is_expected.to route_command('gh whois theckman').to(:whois) }
   it { is_expected.to route_command('gh user theckman').to(:whois) }
 
-  describe '#default_config' do
-    it 'should set default team to nil' do
-      expect(Lita.config.handlers.github.default_team_slug).to be_nil
+  describe '#config' do
+    it 'should set default teams to nil' do
+      expect(Lita.config.handlers.github.default_team_slugs).to be_nil
     end
 
     it 'should set repos to private by default' do


### PR DESCRIPTION
The pessimistic version constraint has been updated to support lita
versions >= 4.0.
`default_config` has been deprecated, and all config values must be
declared.
See http://docs.lita.io/releases/4/ for more info.